### PR TITLE
STARTTLS support on non-SSL sockets

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mmemail "1.0.0"
+(defproject mmemail "1.0.1"
   :description "Simple email delivery with just one jar!"
   :dependencies [[org.clojure/clojure "1.1.0"]
                  [org.clojure/clojure-contrib "1.1.0"]])

--- a/src/mmemail/helper.clj
+++ b/src/mmemail/helper.clj
@@ -6,8 +6,11 @@
       (.put "mail.smtp.host" (:host map))
       (.put "mail.smtp.port" (:port map))
       (.put "mail.smtp.user" (:user map))
-      (.put "mail.smtp.socketFactory.port" (:port map))
       (.put "mail.smtp.auth" "true"))
+    (if (or (or (= (:starttls map) true) (= (:starttls map) "true"))
+            (or (= (:ssl map) true) (= (:ssl map) "true")))
+      (doto props
+        (.put "mail.smtp.starttls.enable" "true")))
     (if (or (= (:ssl map) true) (= (:ssl map) "true"))
       (doto props
         (.put "mail.smtp.starttls.enable" "true")


### PR DESCRIPTION
Hi,

I have added support for STARTTLS on non-SSL sockets so that it can be used on port 25.
